### PR TITLE
Added quickfix for oddNumberOfArguementsForHashErr

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -461,7 +461,7 @@ module Google
     def self.parse_recurrence_rule(recurrence_entry)
       return {} unless recurrence_entry && recurrence_entry != []
 
-      rrule = recurrence_entry[0].sub('RRULE:', '')
+      rrule = /(?<=RRULE:)(.*)(?="\])/.match(recurrence_entry.to_s).to_s
       rhash = Hash[*rrule.downcase.split(/[=;]/)]
 
       rhash[:until] = Time.parse(rhash[:until]) if rhash[:until]


### PR DESCRIPTION
Source of fix is an updated version of this file: https://github.com/northworld/google_calendar/blob/master/lib/google/event.rb

stack of error
```
/home/user/icalsync/config.rb:1: Use RbConfig instead of obsolete and deprecated Config.
/home/user/icalsync/lib/google/event.rb:465:in `[]': odd number of arguments for Hash (ArgumentError)
	from /home/user/icalsync/lib/google/event.rb:465:in `parse_recurrence_rule'
	from /home/user/icalsync/lib/google/event.rb:451:in `new_from_feed'
	from /home/user/icalsync/lib/google/event.rb:248:in `block in build_from_google_feed'
	from /home/user/icalsync/lib/google/event.rb:248:in `collect'
	from /home/user/icalsync/lib/google/event.rb:248:in `build_from_google_feed'
	from /home/user/icalsync/lib/google/calendar.rb:288:in `block in event_lookup_all'
	from /home/user/icalsync/lib/google/calendar.rb:275:in `loop'
	from /home/user/icalsync/lib/google/calendar.rb:275:in `event_lookup_all'
	from /home/user/icalsync/lib/google/calendar.rb:103:in `events_all'
	from /home/user/icalsync/icalsync.rb:244:in `sync'
	from main.rb:30:in `<main>'
```